### PR TITLE
ipf_api_client updates

### DIFF
--- a/api_clients/ipf/ipf_api_client.py
+++ b/api_clients/ipf/ipf_api_client.py
@@ -25,11 +25,7 @@ class IPFClient(httpxClient):
         except AssertionError:
             raise RuntimeError(f"base_url not provided or IPF_URL not set")
 
-        ## if using IPF DEV server, only use /v1, no /api
-        if kwargs["base_url"].find(":8100") != -1:
-            kwargs["base_url"] += "/v1"
-        else:
-            kwargs["base_url"] += "/api/v1"
+        kwargs["base_url"] += "/api/v1"
 
         if not token:
             try:

--- a/api_clients/ipf/ipf_api_client.py
+++ b/api_clients/ipf/ipf_api_client.py
@@ -223,6 +223,9 @@ class IPFClient(httpxClient):
         if pagination:
             payload["pagination"] = pagination
 
+        if snapshot_id == "":
+            snapshot_id = "$last"
+        
         res = self.post(url, json=payload)
         res.raise_for_status()
         body = res.json()

--- a/api_clients/ipf/ipf_api_client.py
+++ b/api_clients/ipf/ipf_api_client.py
@@ -116,7 +116,7 @@ class IPFClient(httpxClient):
         self,
         filters: Optional[Dict] = None,
         pagination: Optional[Dict] = None,
-        snapshot_id: Optional[str] = None,
+        snapshot_id: Optional[str] = "$last",
     ):
         """
         Method to fetch the list of sites from the IPF instance opened in the API client, or the one entered
@@ -136,6 +136,9 @@ class IPFClient(httpxClient):
             }
         ]
         """
+        if snapshot_id == "":
+            snapshot_id = "$last"
+            
         sites = self.fetch_table(
             "tables/inventory/sites",
             columns=["siteName", "id", "siteKey", "devicesCount"],
@@ -149,7 +152,7 @@ class IPFClient(httpxClient):
         self,
         filters: Optional[Dict] = None,
         pagination: Optional[Dict] = None,
-        snapshot_id: Optional[str] = None,
+        snapshot_id: Optional[str] = "$last",
     ):
         """
         Method to fetch the list of devices from the IPF instance opened in the API client, or the one entered
@@ -175,6 +178,9 @@ class IPFClient(httpxClient):
             }
         ]
         """
+        if snapshot_id == "":
+            snapshot_id = "$last"
+
         devices = self.fetch_table(
             "tables/inventory/devices",
             columns=[
@@ -201,7 +207,7 @@ class IPFClient(httpxClient):
         columns: List[str],
         filters: Optional[Dict] = None,
         pagination: Optional[Dict] = None,
-        snapshot_id: Optional[str] = None,
+        snapshot_id: Optional[str] = "$last",
     ):
         """
         Method to fetch data from IP Fabric tables.

--- a/api_clients/ipf/ipf_api_client.py
+++ b/api_clients/ipf/ipf_api_client.py
@@ -92,6 +92,26 @@ class IPFClient(httpxClient):
 
         return snap_list
 
+    def fetch_last_snapshot_id(self):
+        """
+        Method to return the latest loaded snapshotfrom the IPF instance opened in the API client.
+
+        Takes no additional parameters.
+        Returns the ID of the latest snapshot as a string
+        """
+        res = self.get("/snapshots")
+        res.raise_for_status()
+
+        # Fetch last loaded snapshot info from IP Fabric
+        lastLoaded = False
+        for snap in res.json():
+            if snap["state"] == "loaded":
+                if not lastLoaded:
+                    lastSnap = snap["id"]
+                    lastLoaded = True
+                    break
+        return lastSnap
+    
     def site_list(
         self,
         filters: Optional[Dict] = None,

--- a/api_clients/ipf/ipf_api_client.py
+++ b/api_clients/ipf/ipf_api_client.py
@@ -123,15 +123,31 @@ class IPFClient(httpxClient):
             {
                 'hostname': device hostname,
                 'siteName': name of the site where the device belongs,
+                'loginIp': IP used for IP Fabric to login to this device,
+                'loginType': method used to connect to the device,
                 'vendor': vendor for this device,
-                'platform': platform for this device,
-                'loginIp': IP used for IP Fabric to login to this device
+                'platform': platform of this device,
+                'family': family of this device,
+                'version': OS version running on this device,
+                'sn': Serial Number of the device,
+                'devType': Type of device,
             }
         ]
         """
         devices = self.fetch_table(
             "tables/inventory/devices",
-            columns=["hostname", "siteName", "vendor", "platform", "loginIp"],
+            columns=[
+                "hostname",
+                "siteName",
+                "loginIp",
+                "loginType",
+                "vendor",
+                "platform",
+                "family",
+                "version",
+                "sn",
+                "devType",
+            ],
             filters=filters,
             pagination=pagination,
             snapshot_id=snapshot_id,


### PR DESCRIPTION
1- added a few columns in the ipf.device_list(), to make the list compatible with the script to build Ansible inventory
2- snapshot_id: you can't use "$prev" as a SnapshotId in an endpoint, you have to know the actual ID. 
we now have:
ipf.snapshot_id == the ID of the snapshot (either provided when creating the class, or converted from $xxx)
ipf_snapshot_ref == this is the name used, either $last, $prev, or $lastLocked, Otherwise, it's the  string "N/A - only ID was provided"
3- function to return the last snapshot ID: fetch_last_snapshot_id()